### PR TITLE
Host form tweaks, update formatting of meeting ping messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ database.properties
 # Meeting Pings Schema
 src/meeting-pings/meetingPingsSchema.ts
 src/meeting-pings/meetingPingsSchema.production.ts
+src/meeting-pings/meetingPingsSchema.testing.ts

--- a/src/event-notion/NotionEvent.ts
+++ b/src/event-notion/NotionEvent.ts
@@ -105,8 +105,8 @@ const needsBooking = (response: HostFormResponse): 'Booking N/A' | 'Booking TODO
  * @returns The Notion Option for Recording requirement.
  */
 const needsRecording = (response: HostFormResponse): 'Yes' | 'No' => {
-  return (response['Will you want a recording of your event uploaded to the ACM YouTube channel?'] === 'Yes'
-  || response['Will you want a recording of your in person event uploaded to the ACM YouTube channel? '] === 'Yes')
+  return (response['Will you want a recording of your event uploaded to the ACM YouTube channel?'] 
+          === 'Yes, I will record it myself and send the Events team a link')
     ? 'Yes'
     : 'No';
 };

--- a/src/managers/GoogleCalendarManager.ts
+++ b/src/managers/GoogleCalendarManager.ts
@@ -111,7 +111,7 @@ export default class {
               }
               const channel = client.channels.cache.get(this.calendarMapping[calendarID].getChannelID()) as TextChannel;
               channel.send({
-                content: `${mentions} Meeting starting <t:${Math.trunc(startTime.toSeconds())}:R>!`,
+                content: `Meeting starting <t:${Math.trunc(startTime.toSeconds())}:R>! ${mentions}`,
                 embeds: [messageEmbed],
               });
             }

--- a/src/meeting-pings/index.ts
+++ b/src/meeting-pings/index.ts
@@ -38,15 +38,27 @@ export class DiscordInfo {
      */
     if (event.attendees && event.creator && event.creator.email) {
       let mentions = '';
+      /** 
+       * Flag indicating if an attendee has successfully been 
+       * found in the mapping and added to the ping list.
+       */
+      let attendeeAdded = false;
+
       for (const attendee of event.attendees) {
         if (attendee.email && calendarGuestMap[attendee.email]) {
-          mentions += `<@${calendarGuestMap[attendee.email]}>`;
+          // Special case to make sure the formatted string is correctly separated by spaces.
+          if (!attendeeAdded) {
+            attendeeAdded = true;
+            mentions += `<@${calendarGuestMap[attendee.email]}>`;
+          } else {
+            mentions += ` <@${calendarGuestMap[attendee.email]}>`;
+          }
         }
       }
       /**
        * If none of their emails were in our mapping, we'll default to pinging the role.
        */
-      if (mentions === '') {
+      if (!attendeeAdded) {
         return `<@&${this.mentions}>`;
       }
       /**
@@ -54,7 +66,7 @@ export class DiscordInfo {
        * so we'll add the mention for the creator of the event at the start.
        */
       if (calendarGuestMap[event.creator.email]) {
-        mentions = `<@${calendarGuestMap[event.creator.email]}>` + mentions;
+        mentions = `<@${calendarGuestMap[event.creator.email]}> ` + mentions;
       }
       return mentions;
     }


### PR DESCRIPTION
- Upcoming meeting messages now have "Meeting starting in ___!" followed by pings instead of pings first
  - Made this change because meetings have a lot of guests, which are pushing the timestamp away from the top of the message
- Pings are now separated by spaces for clarity

- Host form imports now add Recording field correctly

[New reformatted meeting pings]
<img width="882" alt="Screen Shot 2022-07-07 at 3 16 26 PM" src="https://user-images.githubusercontent.com/27360825/177880658-ee01d3e5-014c-4461-82f2-b2ec82606ce0.png">
[Kartana now correctly ports the "Recording" field on a test event]
<img width="587" alt="Screen Shot 2022-07-07 at 3 17 29 PM" src="https://user-images.githubusercontent.com/27360825/177880757-a23cd05e-1819-45e7-9a82-8fabefb2684a.png">