### PR TITLE
Configure absolute import paths

### DIFF
--- a/src/commands/Deadlines.ts
+++ b/src/commands/Deadlines.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
-import Command from '../Command';
-import { BotClient } from '../types';
+import Command from 'src/Command';
+import { BotClient } from 'src/types';
 
 /**
  * Manually syncs the Event Host Form with the Notion Events calendar. 

--- a/src/commands/MeetingNotes.ts
+++ b/src/commands/MeetingNotes.ts
@@ -1,8 +1,8 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, MessageEmbed } from 'discord.js';
 import { DateTime } from 'luxon';
-import Command from '../Command';
-import { BotClient } from '../types';
+import Command from 'src/Command';
+import { BotClient } from 'src/types';
 
 /**
  * Makes a new meeting note on Notion and provides a link to it.

--- a/src/commands/Ping.ts
+++ b/src/commands/Ping.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
-import Command from '../Command';
-import { BotClient } from '../types';
+import Command from 'src/Command';
+import { BotClient } from 'src/types';
 
 /**
  * Pings the user.

--- a/src/commands/RefreshCalendar.ts
+++ b/src/commands/RefreshCalendar.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
-import Command from '../Command';
-import { BotClient } from '../types';
+import Command from 'src/Command';
+import { BotClient } from 'src/types';
 
 /**
  * Checks all Google Calendars for meetings happening this minute..

--- a/src/commands/Sync.ts
+++ b/src/commands/Sync.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
-import Command from '../Command';
-import { BotClient } from '../types';
+import Command from 'src/Command';
+import { BotClient } from 'src/types';
 
 /**
  * Manually syncs the Event Host Form with the Notion Events calendar. 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-import { BotSettings } from '../types';
+import { BotSettings } from 'src/types';
 
 export default {
   apiKeys: {

--- a/src/event-notion/NotionEvent.ts
+++ b/src/event-notion/NotionEvent.ts
@@ -11,8 +11,8 @@ import {
   StudentOrg,
   isStudentOrg,
   notionYoutubeAnswer,
-} from '../types';
-import Logger from '../utils/Logger';
+} from 'src/types';
+import Logger from 'src/utils/Logger';
 
 /**
  * Convert a piece of Markdown-compliant text to a RichTextItemRequest for

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -1,11 +1,11 @@
 import { Client } from '@notionhq/client';
-import Logger from '../utils/Logger';
-import { notionCalSchema, googleSheetSchema } from '../assets';
+import Logger from 'src/utils/Logger';
+import { notionCalSchema, googleSheetSchema } from 'src/assets';
 import { GetDatabaseResponse } from '@notionhq/client/build/src/api-endpoints';
 import { diff } from 'json-diff-ts';
 import { groupBy, isEqual } from 'lodash';
 import NotionEvent from './NotionEvent';
-import { GoogleSheetsSchemaMismatchError, HostFormResponse, NotionSchemaMismatchError } from '../types';
+import { GoogleSheetsSchemaMismatchError, HostFormResponse, NotionSchemaMismatchError } from 'src/types';
 import { GoogleSpreadsheet, GoogleSpreadsheetRow, ServiceAccountCredentials } from 'google-spreadsheet';
 import { MessageEmbed, WebhookClient } from 'discord.js';
 import { DateTime } from 'luxon';

--- a/src/events/InteractionCreate.ts
+++ b/src/events/InteractionCreate.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { CommandInteraction } from 'discord.js';
-import Logger from '../utils/Logger';
-import { BotEvent, BotClient } from '../types';
+import Logger from 'src/utils/Logger';
+import { BotEvent, BotClient } from 'src/types';
 
 /**
  * The InteractionCreate Event is called whenever someone creates an interaction with a bot,

--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -1,5 +1,5 @@
-import Logger from '../utils/Logger';
-import { BotClient, BotEvent } from '../types';
+import Logger from 'src/utils/Logger';
+import { BotClient, BotEvent } from 'src/types';
 
 /**
  * The Ready event is triggered when the bot is fully connected to the Discord API.

--- a/src/managers/ActionManager.ts
+++ b/src/managers/ActionManager.ts
@@ -4,9 +4,9 @@ import { Service } from 'typedi';
 import { join } from 'path';
 import { readdir, statSync } from 'fs';
 import { Routes } from 'discord-api-types/v9';
-import { BotClient } from '../types';
-import Command from '../Command';
-import Logger from '../utils/Logger';
+import { BotClient } from 'src/types';
+import Command from 'src/Command';
+import Logger from 'src/utils/Logger';
 
 /**
  * ActionManager dynamically managed all of the respective Commands and Events

--- a/src/managers/GoogleCalendarManager.ts
+++ b/src/managers/GoogleCalendarManager.ts
@@ -1,11 +1,11 @@
 import { Service } from 'typedi';
 import schedule from 'node-schedule';
-import { BotClient } from '../types';
-import Logger from '../utils/Logger';
+import { BotClient } from 'src/types';
+import Logger from 'src/utils/Logger';
 import { DateTime, Interval } from 'luxon';
 import { calendar_v3, google } from 'googleapis';
 import { ColorResolvable, MessageEmbed, TextChannel } from 'discord.js';
-import { MeetingPingsSchema, DiscordInfo } from '../meeting-pings';
+import { MeetingPingsSchema, DiscordInfo } from 'src/meeting-pings';
 
 /**
  * GoogleCalendarManager manages automatic event notifications on Discord of events on

--- a/src/managers/NotionEventSyncManager.ts
+++ b/src/managers/NotionEventSyncManager.ts
@@ -1,13 +1,13 @@
 
 import { Service } from 'typedi';
 import schedule from 'node-schedule';
-import { BotClient } from '../types';
-import Logger from '../utils/Logger';
-import { syncHostFormToNotionCalendar, pingForDeadlinesAndReminders } from '../event-notion';
+import { BotClient } from 'src/types';
+import Logger from 'src/utils/Logger';
+import { syncHostFormToNotionCalendar, pingForDeadlinesAndReminders } from 'src/event-notion';
 import { readFileSync } from 'fs';
 import { MessageEmbed, TextChannel, WebhookClient } from 'discord.js';
-import { GoogleSheetsSchemaMismatchError, NotionSchemaMismatchError } from '../types';
-import { generateNewNote } from '../notes-notion';
+import { GoogleSheetsSchemaMismatchError, NotionSchemaMismatchError } from 'src/types';
+import { generateNewNote } from 'src/notes-notion';
 import { DateTime } from 'luxon';
 
 /**

--- a/src/notes-notion/NotionNote.ts
+++ b/src/notes-notion/NotionNote.ts
@@ -1,8 +1,8 @@
 import { Client } from '@notionhq/client/build/src';
 import { CreatePageParameters } from '@notionhq/client/build/src/api-endpoints';
 import { DateTime } from 'luxon';
-import { toNotionRichText } from '../event-notion/NotionEvent';
-import Logger from '../utils/Logger';
+import { toNotionRichText } from 'src/event-notion/NotionEvent';
+import Logger from 'src/utils/Logger';
 
 /**
  * NotionNote is a representation of an note stored in Notion Meeting Notes.

--- a/src/notes-notion/index.ts
+++ b/src/notes-notion/index.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { getNotionAPI } from '../event-notion';
+import { getNotionAPI } from 'src/event-notion';
 import NotionNote from './NotionNote';
 
 export interface NotesNotionPipelineConfig {

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -10,9 +10,9 @@ import {
   MessagePayload,
   InteractionReplyOptions,
 } from 'discord.js';
-import Command from '../Command';
-import GoogleCalendarManager from '../managers/GoogleCalendarManager';
-import NotionEventSyncManager from '../managers/NotionEventSyncManager';
+import Command from 'src/Command';
+import GoogleCalendarManager from 'src/managers/GoogleCalendarManager';
+import NotionEventSyncManager from 'src/managers/NotionEventSyncManager';
   
 /**
  * The options for a Command.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "moduleResolution": "node",
     "sourceRoot": "src",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "baseUrl": "."
   },
   "include": [
     "src", "src/jsModuleDecs.d.ts"


### PR DESCRIPTION
## Change
We can configure our tsconfig file with 
```
"compilerOptions": {
    "baseUrl" : "."
}
```
to tell it to resolve file imports relative to the root path of the project directory. 

## Coding Convention
A good convention to follow is to use relative paths '../../' only for components in the same folder level (e.g. `import { example } from './example'`) and absolute paths otherwise

## Benefits
This keeps the code more readable by avoiding import statements that look like `import x from '../../../someFile'` and also makes it easier for VSCode to automatically fix import paths if you ever have to move a file to a different folder.