### PR TITLE
Update date in title of meeting notes to include leading 0

### DIFF
--- a/src/commands/MeetingNotes.ts
+++ b/src/commands/MeetingNotes.ts
@@ -48,7 +48,7 @@ export default class MeetingNotes extends Command {
     }
     
     // We automatically add the date of the note to the start of the title.
-    const title = date.toLocaleString(DateTime.DATE_SHORT) + ' ' + interaction.options.getString('title', true);
+    const title = date.toFormat('MM/dd/yyyy') + ' ' + interaction.options.getString('title', true);
     const url = await this.client.notionEventSyncManager.generateMeetingNotes(this.client, title, date);
     if (url) {
       // If the url isn't empty, the note was successfully made!


### PR DESCRIPTION
- Update formatting of date in title of generated meeting notes to include 0 (Previously: 1/1/2022, now 01/01/2022)
- Changed for consistency with other meeting notes on Notion, helps sorting behavior for titles
<img width="619" alt="Screen Shot 2022-08-22 at 12 18 42 PM" src="https://user-images.githubusercontent.com/27360825/186001331-7bf2ecf5-c86e-419e-9267-76be27c333bb.png">

