### PR TITLE
Cap wait time at 1000 hours, weird behavior when wait is too long

### DIFF
--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -78,6 +78,13 @@ export default class ScheduleSend extends Command {
       return;
     }
 
+    if (hoursFromNow > 1000) {
+      super.respond(interaction, {
+        content: 'Exceeded maximum wait time! We cap it at 1000 hours in the future',
+        ephemeral: true,
+      });
+    }
+
     // Creates date object with time to send
     const dateToSend = date.plus({ hours: hoursFromNow, minutes: minutesFromNow });
 

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -78,11 +78,13 @@ export default class ScheduleSend extends Command {
       return;
     }
 
+    // Cap wait time, strange behavior occurs if time overflows and becomes NaN
     if (hoursFromNow > 1000) {
       super.respond(interaction, {
-        content: 'Exceeded maximum wait time! We cap it at 1000 hours in the future',
+        content: 'Exceeded maximum wait time! I won\'t wait longer than 1000 hours to send a message',
         ephemeral: true,
       });
+      return;
     }
 
     // Creates date object with time to send

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -81,7 +81,7 @@ export default class ScheduleSend extends Command {
     // Cap wait time, strange behavior occurs if time overflows and becomes NaN
     if (hoursFromNow > 1000) {
       super.respond(interaction, {
-        content: 'Exceeded maximum wait time! I won\'t wait longer than 1000 hours to send a message',
+        content: 'Exceeded maximum wait time! I won\'t wait longer than 1000 hours to send a message.',
         ephemeral: true,
       });
       return;


### PR DESCRIPTION
 - Fix error where overflow of hour time causes NaN time, sending a message at every minute
 - Cap wait time at 1000 hours (~41 days)
Error: ![image](https://user-images.githubusercontent.com/27360825/187046760-f4506682-99d9-4aec-a53e-317e5186abad.png)
Fix:
<img width="877" alt="Screen Shot 2022-08-27 at 1 28 15 PM" src="https://user-images.githubusercontent.com/27360825/187046909-a48f7be9-e811-4031-8a35-b4ad7d449d64.png">

