### PR TITLE
Add 'Intake Form N/A' back to event porting, add type guards in pingF…

### DIFF
--- a/src/event-notion/NotionEvent.ts
+++ b/src/event-notion/NotionEvent.ts
@@ -64,11 +64,14 @@ const needsTAPForm = (response: HostFormResponse): 'TAP N/A' | 'TAP TODO' => {
  * @returns The Notion Option for CSI Intake Form status.
  */
 const needsIntakeForm = (response: HostFormResponse): 'Intake Form N/A' | 'Intake Form TODO' => {
+  return 'Intake Form N/A';
+  /** We currently don't need intake forms, so this is commented out.
   return (response['Where is your event taking place?'] === 'My event is on Zoom'
   || response['Where is your event taking place?'] === 'My event is on Discord only'
   || response['Where is your event taking place?'] === 'My event is off campus')
     ? 'Intake Form N/A'
     : 'Intake Form TODO';
+  */
 };
 
 /**
@@ -551,12 +554,9 @@ export default class NotionEvent {
         'CSI Form Status': {
           select: { name: this.csiFormStatus },
         },
-        /**
-         * We currently don't need intake forms, so this is commented out.
         'Intake Form Status': {
           select: { name: this.intakeFormStatus },
         },
-        */
         'TAP Status': {
           select: { name: this.TAPStatus },
         },

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -452,9 +452,15 @@ export const pingForTAPandCSIDeadlines = async (notion: Client,
     if (event.properties.Name.type !== 'title') {
       return false;
     }
+    let tapStatus = 'TAP N/A';
+    let csiStatus = 'Intake Form N/A';
+    if (event.properties['TAP Status'].select) {
+      tapStatus = event.properties['TAP Status'].select.name;
+    }
+    if (event.properties['Intake Form Status'].select) {
+      csiStatus = event.properties['Intake Form Status'].select.name;
+    }
     const date = event.properties.Date.date.start;
-    const tapStatus = event.properties['TAP Status'].select.name;
-    const csiStatus = event.properties['Intake Form Status'].select.name;
     
     if (orgPing === 'TAP') {
       return date === deadlineDate.toISODate() && tapStatus === status;

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -452,14 +452,15 @@ export const pingForTAPandCSIDeadlines = async (notion: Client,
     if (event.properties.Name.type !== 'title') {
       return false;
     }
-    let tapStatus = 'TAP N/A';
-    let csiStatus = 'Intake Form N/A';
-    if (event.properties['TAP Status'].select) {
-      tapStatus = event.properties['TAP Status'].select.name;
-    }
-    if (event.properties['Intake Form Status'].select) {
-      csiStatus = event.properties['Intake Form Status'].select.name;
-    }
+
+    // If the field is left blank on Notion, event.properties[...].select
+    // will be null, so we'll automatically fill it to 'N/A' if so.
+    const tapSelect = event.properties['TAP Status'].select;
+    const tapStatus = tapSelect ? tapSelect.name : 'TAP N/A';
+
+    const csiSelect = event.properties['Intake Form Status'].select;
+    const csiStatus = csiSelect ? csiSelect.name : 'Intake Form N/A';
+
     const date = event.properties.Date.date.start;
     
     if (orgPing === 'TAP') {


### PR DESCRIPTION
- Kartana crashes when pinging for TAP and CSI deadlines when one of the fields 'Intake Form Status' or 'TAP Status' isn't filled out
- Fixed by adding Intake form back to imported Notion Events
- Added a type guard to isEventPingable so this issue won't happen in the future