### PR TITLE
Notion schema update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ GOOGLE_SHEETS_KEY_FILE=
 GOOGLE_SHEETS_DOC_ID=
 GOOGLE_SHEETS_SHEET_NAME=
 
+# Discord Guild (server) ID to speed up porting of slash commands.
+DISCORD_GUILD_ID=
+
 # Discord webhook URL for any alerts pipeline makes.
 DISCORD_WEBHOOK_URL=
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Kartana does so by:
 - forming a Notion card that can be added to the Notion Calendar base
 - creating the Notion card on the calendar
 - sending a notification to Events team that something new has been added
-  through Discord.
+  through Discord
 
 **Note:**
 If the Notion calendar schema is edited, corresponding changes need to be made in [src/assets/notionCalSchema.ts](./src/assets/notionCalSchema.ts)
@@ -38,9 +38,9 @@ Kartana can automatically send meeting notification messages to our
 Discord server corresponding to events on our team Google Calendars.
 
 Kartana does so by:
-- reading each Google Calendar for meetings occurring an hour from now or right now every 30 minutes
-- building a message embed on Discord with information taken from the Google Calendar event
-- sending the message to the team's corresponding Discord channel and notifying the people involved.
+- checking each Google Calendar every 15 minutes for meetings occurring right now or an hour from now
+- building a message embed on Discord with information taken from the upcoming Google Calendar event
+- sending the message to the team's corresponding Discord channel and notifying the people involved
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ Kartana does so by:
 - sending a notification to Events team that something new has been added
   through Discord.
 
+**Note:**
+If the Notion calendar schema is edited, corresponding changes need to be made in [src/assets/notionCalSchema.ts](./src/assets/notionCalSchema.ts)
+
+To update the schema:
+- make sure `NOTION_CALENDAR_ID` in the .env file matches with the Notion Calendar
+- run `node get-database-props.js`
+- copy the contents that appear in the file `database.properties`
+- format the contents using a JSON formatter and paste it in `src/assets/notionCalSchema.ts`
+
+## Meeting Pings
+
+Kartana can automatically send meeting notification messages to our
+Discord server corresponding to events on our team Google Calendars.
+
+Kartana does so by:
+- reading each Google Calendar for meetings occurring an hour from now or right now every 30 minutes
+- building a message embed on Discord with information taken from the Google Calendar event
+- sending the message to the team's corresponding Discord channel and notifying the people involved.
+
 # Usage
 
 Fill the `.env.example` file with the necessary credentials and URL's and save it

--- a/get-database-props.js
+++ b/get-database-props.js
@@ -1,0 +1,13 @@
+let dotenv = require('dotenv');
+
+dotenv.config();
+
+(async () => {
+    console.log('Saving properties of prod calendar in file...');
+    const notion = require('@notionhq/client');
+    const client = new notion.Client({ auth: process.env.NOTION_INTEGRATION_TOKEN });
+    const database_props = await (await client.databases.retrieve({ database_id: process.env.NOTION_CALENDAR_ID })).properties;
+    console.log('Done querying! Saving to file...');
+    require('fs').writeFileSync('database.properties', JSON.stringify(database_props, 2));
+    console.log('Done!');
+})()

--- a/get-database-props.js
+++ b/get-database-props.js
@@ -1,4 +1,4 @@
-let dotenv = require('dotenv');
+const dotenv = require('dotenv');
 
 dotenv.config();
 
@@ -6,7 +6,8 @@ dotenv.config();
     console.log('Saving properties of prod calendar in file...');
     const notion = require('@notionhq/client');
     const client = new notion.Client({ auth: process.env.NOTION_INTEGRATION_TOKEN });
-    const database_props = await (await client.databases.retrieve({ database_id: process.env.NOTION_CALENDAR_ID })).properties;
+    const database_info = await client.databases.retrieve({ database_id: process.env.NOTION_CALENDAR_ID })
+    const database_props = await database_info.properties;
     console.log('Done querying! Saving to file...');
     require('fs').writeFileSync('database.properties', JSON.stringify(database_props, 2));
     console.log('Done!');

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -142,6 +142,13 @@ export default class Client extends DiscordClient implements BotClient {
       });
       throw new Error('Could not construct Client class: missing Google Sheets Sheet Name in envvars');
     }
+    if (!process.env.DISCORD_GUILD_ID) {
+      Logger.error('Could not construct Client class: missing Discord Guild ID in envvars', {
+        eventType: 'initError',
+        error: 'missing Discord Guild ID in envvars',
+      });
+      throw new Error('Could not construct Client class: missing Discord Guild ID in envvars');
+    }
     if (!process.env.DISCORD_WEBHOOK_URL) {
       Logger.error('Could not construct Client class: missing Discord Webhook URL in envvars', {
         eventType: 'initError',
@@ -177,6 +184,7 @@ export default class Client extends DiscordClient implements BotClient {
     this.settings.googleSheetsKeyFile = process.env.GOOGLE_SHEETS_KEY_FILE;
     this.settings.googleSheetsDocID = process.env.GOOGLE_SHEETS_DOC_ID;
     this.settings.googleSheetsSheetName = process.env.GOOGLE_SHEETS_SHEET_NAME;
+    this.settings.discordGuildID = process.env.DISCORD_GUILD_ID;
     this.settings.discordWebhookURL = process.env.DISCORD_WEBHOOK_URL;
     this.settings.maintainerID = process.env.DISCORD_MAINTAINER_MENTION_ID;
     this.settings.logisticsTeamID = process.env.DISCORD_LOGISTICS_TEAM_MENTION_ID;

--- a/src/assets/googleSheetSchema.ts
+++ b/src/assets/googleSheetSchema.ts
@@ -38,4 +38,5 @@ export const googleSheetSchema = [
   'If you need tech or equipment, please specify here',
   'Food Pickup Time',
   'I understand that I will arrange someone to pickup the food or other items required for my event',
+  'Check-in Code',
 ];

--- a/src/assets/notionCalSchema.ts
+++ b/src/assets/notionCalSchema.ts
@@ -3,7 +3,7 @@
  * 
  * This effectively is a copy of the `database.properties` JSON object
  * extracted from a copy of the ACM UCSD Notion Calendar as of
- * Sun, Jun 12 2022 19:54:13 PST.
+ * Sun, Oct 2 2022 19:54:13 PST.
  */
 export const notionCalSchema = {
   'Funding Status': {
@@ -993,6 +993,14 @@ export const notionCalSchema = {
     'name': 'PR Requests',
     'type': 'rich_text',
     'rich_text': {},
+  },
+  'AS Funding Attendance': {
+    'id': 'g%3Bvm',
+    'name': 'AS Funding Attendance',
+    'type': 'number',
+    'number': {
+      'format': 'number',
+    },
   },
   'AV Equipment': {
     'id': 'hYL%3D',

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -35,6 +35,7 @@ export default {
   googleSheetsKeyFile: '',
   googleSheetsDocID: '',
   googleSheetsSheetName: '',
+  discordGuildID: '',
   discordWebhookURL: '',
   maintainerID: '',
   logisticsTeamID: '',

--- a/src/event-notion/NotionEvent.ts
+++ b/src/event-notion/NotionEvent.ts
@@ -446,7 +446,7 @@ export default class NotionEvent {
     // eslint-disable-next-line max-len
     this.recordingRequests = formResponse['If yes to the previous question, do you have any special recording requests?'];
     this.eventCoordinator = null;
-    this.checkinCode = '';
+    this.checkinCode = formResponse['Check-in Code'];
     this.fbCoHost = '';
     this.recording = needsRecording(formResponse);
     this.bookingStatus = needsBooking(formResponse);
@@ -643,6 +643,12 @@ export default class NotionEvent {
         // "YouTube Link" omitted.
         //
         // We don't get this from the host form.
+        ...(this.checkinCode ? {
+          'Check-in Code': {
+            rich_text: toNotionRichText(this.checkinCode),
+          },
+        } : {}),
+
         ...(this.prRequests ? {
           'PR Requests': {
             rich_text: toNotionRichText(this.prRequests),

--- a/src/managers/ActionManager.ts
+++ b/src/managers/ActionManager.ts
@@ -80,6 +80,11 @@ export default class {
           Routes.applicationCommands(client.settings.clientID),
           { body: slashCommands },
         );
+        // Adding the ID for our Discord Guild allows new slash commands to load faster than adding it globally.
+        await restAPI.put(
+          Routes.applicationGuildCommands(client.settings.clientID, client.settings.discordGuildID),
+          { body: slashCommands },
+        );
         Logger.info('Loaded Slash Commands on Discord Gateway!', {
           eventType: 'slashCommandLoaded',
         });

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -131,6 +131,10 @@ export interface BotSettings {
   googleSheetsDocID: string;
   googleSheetsSheetName: string;
   /**
+   * Discord Guild (server) ID to speed up porting of new slash commands.
+   */
+  discordGuildID: string;
+  /**
    * Discord webhook URL for any alerts pipeline makes.
    */
   discordWebhookURL: string;


### PR DESCRIPTION
- Update Notion Schema
  - Add porting of Check-in Code from host form to Notion Calendar
  - Add AS Funding Attendance to Notion Schema
- Add Discord Guild ID as an envvar to simplify deployments in the future (no more specific distinguishing between testing and deployment for ActionManager.ts)
- Add get-database-props.js so Notion Calendar schemas are easier to update in the future
- Update README to describe process of maintaining Notion Calendar schema, add meeting pings section