### PR TITLE
Scheduled message db

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -170,6 +170,15 @@ export default class Client extends DiscordClient implements BotClient {
       });
       throw new Error('Could not construct Client class: missing Discord Bot Error Channel ID in envvars');
     }
+
+    if (!process.env.SCHEDULED_MESSAGE_GOOGLE_CALENDAR_ID) {
+      Logger.error('Could not construct Client class: missing Scheduled Message Calendar ID in envvars', {
+        eventType: 'initError',
+        error: 'missing Discord Bot Error Channel ID in envvars',
+      });
+      throw new Error('Could not construct Client class: missing Scheduled Message Calendar ID in envvars'); 
+    }
+
     this.settings.notionIntegrationToken = process.env.NOTION_INTEGRATION_TOKEN;
     this.settings.notionCalendarID = process.env.NOTION_CALENDAR_ID;
     this.settings.notionMeetingNotesID = process.env.NOTION_MEETING_NOTES_ID;
@@ -181,6 +190,7 @@ export default class Client extends DiscordClient implements BotClient {
     this.settings.maintainerID = process.env.DISCORD_MAINTAINER_MENTION_ID;
     this.settings.logisticsTeamID = process.env.DISCORD_LOGISTICS_TEAM_MENTION_ID;
     this.settings.botErrorChannelID = process.env.DISCORD_BOT_ERROR_CHANNEL_ID;
+    this.settings.scheduledMessageGoogleCalendarID = process.env.SCHEDULED_MESSAGE_GOOGLE_CALENDAR_ID;
     this.initialize().then();
   }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -197,6 +197,7 @@ export default class Client extends DiscordClient implements BotClient {
       ActionManager.initializeEvents(this);
       this.notionEventSyncManager.initializeNotionSync(this);
       await this.googleCalendarManager.initializeMeetingPings(this);
+      await this.googleCalendarManager.initializeScheduledMessages(this);
       await this.login(configuration.token);
     } catch (e) {
       Logger.error(`Could not initialize bot: ${e}`);

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -43,7 +43,7 @@ export default class ScheduleSend extends Command {
      * Pull the user input values from the command
      */
     const message = interaction.options.getString('message', true);
-    const member = interaction.member ? interaction.member : '';
+    const member = interaction.member;
     const wait = interaction.options.getString('wait', true);
 
     // Checking if the time is valid

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -10,8 +10,10 @@ import Logger from '../utils/Logger';
  * for a user specified time.
  * 
  * 
- * The command will run a cronjob to send the message. Currently
- * there is a 1000 hour limit on scheduled messages.
+ * The command will first create a calendar event with details 
+ * necessary for sending the event (see Google Calendar Manager).
+ * It then schedules a message using a cronjob.
+ * Currently there is a 1000 hour limit on scheduled messages.
  */
 export default class ScheduleSend extends Command {
   
@@ -95,6 +97,10 @@ export default class ScheduleSend extends Command {
       ephemeral: true,
     });
     
+    /**
+     * Checks to make sure the interaction channel exists
+     * Necessary for accessing channel ID value in following channels 
+     */
     if (interaction.channel === null) {
       Logger.error('Channel for scheduled message no longer exists.');
       const errorEmbed = new MessageEmbed()

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -5,7 +5,6 @@ import { BotClient } from '../types';
 import { DateTime } from 'luxon';
 import schedule from 'node-schedule';
 import Logger from '../utils/Logger';
-//import { DiscordInfo } from '../meeting-pings';
 
 /**
  * This command will send a scheduled message after waiting
@@ -16,7 +15,6 @@ import Logger from '../utils/Logger';
  * there is a 1000 hour limit on scheduled messages.
  */
 export default class ScheduleSend extends Command {
-  //private calendar: calendar_v3.Calendar;
   
   constructor(client: BotClient) {
     const definition = new SlashCommandBuilder()
@@ -46,7 +44,7 @@ export default class ScheduleSend extends Command {
      * Pull the user input values from the command
      */
     const message = interaction.options.getString('message', true);
-    const member = interaction.member;
+    const member = interaction.member ? interaction.member : '';
     const wait = interaction.options.getString('wait', true);
 
     // Checking if the time is valid
@@ -112,21 +110,18 @@ export default class ScheduleSend extends Command {
       return;
     }
 
-    this.client.googleCalendarManager
-      .addScheduledMessage(
-        this.client, 
-        interaction.channel.toString(),
-        member?.toString(), 
-        message, 
-        dateToSend);
+    // Add Message to the google calendar
+    this.client.googleCalendarManager.addScheduledMessage(this.client, interaction.channel.toString(),
+      messageToSend, dateToSend);
 
     // Schedules when to send the message 
     schedule.scheduleJob(dateToSend.toJSDate(), async () => {
       Logger.info(`Scheduled a message to be sent at ${dateToSend.toLocaleString(DateTime.DATETIME_SHORT)}`);
       
+
       /**
        * Alert someone if the channel went missing between now and when the message is sent
-       */
+      */
       if (interaction.channel === null) {
         Logger.error('Channel for scheduled message no longer exists.');
         const errorEmbed = new MessageEmbed()

--- a/src/commands/ScheduleSend.ts
+++ b/src/commands/ScheduleSend.ts
@@ -3,7 +3,6 @@ import { CommandInteraction, MessageEmbed, TextChannel } from 'discord.js';
 import Command from '../Command';
 import { BotClient } from '../types';
 import { DateTime } from 'luxon';
-import schedule from 'node-schedule';
 import Logger from '../utils/Logger';
 
 /**
@@ -111,33 +110,11 @@ export default class ScheduleSend extends Command {
     }
 
     // Add Message to the google calendar
-    this.client.googleCalendarManager.addScheduledMessage(this.client, interaction.channel.toString(),
+    this.client.googleCalendarManager.addScheduledMessage(this.client, interaction.channelId,
       messageToSend, dateToSend);
 
-    // Schedules when to send the message 
-    schedule.scheduleJob(dateToSend.toJSDate(), async () => {
-      Logger.info(`Scheduled a message to be sent at ${dateToSend.toLocaleString(DateTime.DATETIME_SHORT)}`);
-      
+    // Schedule the message to be sent
+    this.client.googleCalendarManager.scheduleMessage(this.client, dateToSend, messageToSend, interaction.channelId);
 
-      /**
-       * Alert someone if the channel went missing between now and when the message is sent
-      */
-      if (interaction.channel === null) {
-        Logger.error('Channel for scheduled message no longer exists.');
-        const errorEmbed = new MessageEmbed()
-          .setTitle('⚠️ Error with ScheduleSend!')
-          .setDescription('Error sending scheduled message: Channel no longer exists!')
-          .setColor('DARK_RED');
-        const channel = this.client.channels.cache.get(this.client.settings.botErrorChannelID) as TextChannel;
-        channel.send({
-          content: `*Paging <@&${this.client.settings.maintainerID}>!*`,
-          embeds: [errorEmbed],
-        });
-        return;
-      }
-      
-      // Sends the message to the channel
-      await interaction.channel.send(messageToSend); 
-    });
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -39,4 +39,5 @@ export default {
   maintainerID: '',
   logisticsTeamID: '',
   botErrorChannelID: '',
+  scheduledMessageGoogleCalendarID: '',
 } as BotSettings;

--- a/src/managers/ActionManager.ts
+++ b/src/managers/ActionManager.ts
@@ -78,7 +78,7 @@ export default class {
         });
         await restAPI.put(
           Routes.applicationCommands(client.settings.clientID),
-          { body: slashCommands },
+          { body: slashCommands }, 
         );
         Logger.info('Loaded Slash Commands on Discord Gateway!', {
           eventType: 'slashCommandLoaded',

--- a/src/managers/GoogleCalendarManager.ts
+++ b/src/managers/GoogleCalendarManager.ts
@@ -196,17 +196,26 @@ export default class {
     });
   }
 
-  public async addScheduledMessage(client: BotClient, 
-    channelID: string, mentions: string | undefined, message: string, date: DateTime): 
-    Promise<void> {
+  /**
+   * This method adds a new scheduled message event to the google calendar
+   * @param client The original client, for access to the configuration
+   * @param channelID The id of the channel for the message to be sent to
+   * @param message The message to be sent
+   * @param date The datetime object which specifies when the message should be sent
+   */
+  public async addScheduledMessage(client: BotClient, channelID: string, message: string, date: DateTime): 
+  Promise<void> {
+    //Get the auth token
     await this.refreshAuth(client);
     const entry = ScheduledMessageSchema;
+    //Try adding a event to the calendar
+    //Note event has end time is 5 seconds after start time
     try {
       this.calendar.events.insert({
         'calendarId': entry.calendarID,
         'requestBody': {
           'summary' : 'Scheduled Message',
-          'description' : message + ' ' + channelID + ' ' + mentions,
+          'description' : message + ' ' + channelID,
           start : {
             'dateTime' : date.toString(),
           },

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -143,6 +143,10 @@ export interface BotSettings {
    * Discord channel ID where Google Calendar bot error messages will be sent.
    */
   botErrorChannelID: string;
+  /**
+   * Scheduled Message Calendar ID, used for backing up scheduled messages.
+   */
+  scheduledMessageGoogleCalendarID: string;
 }
   
 /**


### PR DESCRIPTION
Made scheduled send backup messages to google calendar. It now reads events from initialization time to 1000 hours from now so that we don't lose any scheduled messages when the bot goes down. Note that you'll need to add an additional calendar in the meeting-pings-schema, but I can change where those credentials goes if anyone has a preference for that.  