### PR TITLE
Add ACMURL option to /meetingnotes, update Notion event pipeline schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ DISCORD_MAINTAINER_MENTION_ID=
 
 # Discord channel ID where miscellaneous bot error messages will be sent.
 DISCORD_BOT_ERROR_CHANNEL_ID=
+
+# ACMURL credentials
+ACMURL_USERNAME=
+ACMURL_PASSWORD=

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ts-node": "^10.4.0",
     "typedi": "^0.10.0",
     "typescript": "^4.9.4",
+    "uuid": "^9.0.0",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.5"
   },

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -177,13 +177,26 @@ export default class Client extends DiscordClient implements BotClient {
       });
       throw new Error('Could not construct Client class: missing Discord Bot Error Channel ID in envvars');
     }
-
     if (!process.env.SCHEDULED_MESSAGE_GOOGLE_CALENDAR_ID) {
       Logger.error('Could not construct Client class: missing Scheduled Message Calendar ID in envvars', {
         eventType: 'initError',
-        error: 'missing Discord Bot Error Channel ID in envvars',
+        error: 'missing Scheduled Message Calendar ID in envvars',
       });
       throw new Error('Could not construct Client class: missing Scheduled Message Calendar ID in envvars'); 
+    }
+    if (!process.env.ACMURL_USERNAME) {
+      Logger.error('Could not construct Client class: missing ACMURL Username in envvars', {
+        eventType: 'initError',
+        error: 'missing ACMURL Username in envvars',
+      });
+      throw new Error('Could not construct Client class: missing ACMURL Username in envvars');
+    }
+    if (!process.env.ACMURL_PASSWORD) {
+      Logger.error('Could not construct Client class: missing ACMURL Password in envvars', {
+        eventType: 'initError',
+        error: 'missing ACMURL Password in envvars',
+      });
+      throw new Error('Could not construct Client class: missing ACMURL Password in envvars');
     }
 
     this.settings.notionIntegrationToken = process.env.NOTION_INTEGRATION_TOKEN;
@@ -199,6 +212,8 @@ export default class Client extends DiscordClient implements BotClient {
     this.settings.logisticsTeamID = process.env.DISCORD_LOGISTICS_TEAM_MENTION_ID;
     this.settings.botErrorChannelID = process.env.DISCORD_BOT_ERROR_CHANNEL_ID;
     this.settings.scheduledMessageGoogleCalendarID = process.env.SCHEDULED_MESSAGE_GOOGLE_CALENDAR_ID;
+    this.settings.acmurl.username = process.env.ACMURL_USERNAME;
+    this.settings.acmurl.password = process.env.ACMURL_PASSWORD;
     this.initialize().then();
   }
 

--- a/src/acmurl/index.ts
+++ b/src/acmurl/index.ts
@@ -1,0 +1,96 @@
+import got from 'got';
+
+export type ACMURLConfig = {
+  username: string,
+  password: string
+};
+
+/**
+ * Add an ACMURL. Makes one HTTP call to YOURLS' API.
+ *
+ * @param shortlink The short link to make an ACMURL for.
+ * @param longlink The link to point it to.
+ * @param title Title of ACMURL in YOURLS interface.
+ * @private
+ * @returns The new shortened ACMURL.
+ */
+export async function addACMURL(
+  shortlink: string, longlink: string, title: string, config: ACMURLConfig,
+): Promise<string> {
+  const acmurlAPIResponse = await got.post('https://acmurl.com/yourls-api.php', {
+    form: {
+      username: config.username,
+      password: config.password,
+      action: 'shorturl',
+      keyword: shortlink,
+      url: longlink,
+      format: 'json',
+      title,
+    },
+  }).json() as any;
+
+  if (acmurlAPIResponse.status === 'fail') {
+    throw new Error(acmurlAPIResponse.code);
+  }
+  return acmurlAPIResponse.shorturl;
+}
+
+/**
+ * Get the link that is redirected from a given ACMURL. Makes one HTTP call to YOURLS' API.
+ * @param shortlink The short link to check the ACMURL for.
+ * @private
+ * @returns the link that `acmurl.com/shortlink` points to.
+ */
+export async function expandACMURL(shortlink: string, config: ACMURLConfig): Promise<string> {
+  const acmurlAPIResponse = await got.post('https://acmurl.com/yourls-api.php', {
+    form: {
+      username: config.username,
+      password: config.password,
+      action: 'expand',
+      shorturl: shortlink,
+      format: 'json',
+    },
+  }).json() as any;
+  return acmurlAPIResponse !== undefined ? acmurlAPIResponse.longurl : undefined;
+}
+
+/**
+ * Overwrite the current ACMURL with a new one. Makes one HTTP call to YOURLS' API.
+ * @param shortlink The short link to make an ACMURL for.
+ * @param longlink The link to point it to.
+ * @param title Title of ACMURL in YOURLS interface.
+ * @private
+ */
+export async function updateACMURL(
+  shortlink: string, longlink: string, title: string, config: ACMURLConfig,
+): Promise<void> {
+  await got.post('https://acmurl.com/yourls-api.php', {
+    form: {
+      username: config.username,
+      password: config.password,
+      action: 'update',
+      shorturl: shortlink,
+      url: longlink,
+      format: 'json',
+      title,
+    },
+  });
+}
+
+/**
+ * Handle an existing ACMURL by updating it properly.
+ * @param shortlink The short link to make an ACMURL for.
+ * @param longlink The link to point it to.
+ * @param title Title of ACMURL in YOURLS interface.
+ * @private
+ * @returns Tuple of old URL on YOURLS and new ACMURL.
+ */
+export async function handleExistingACMURL(
+  shortlink: string, longlink: string, title: string, config: ACMURLConfig,
+): Promise<[string, string]> {
+  // get the old URL
+  const previousURL = await expandACMURL(shortlink, config);
+  // Add the new one.
+  await updateACMURL(shortlink, longlink, title, config);
+  return [previousURL, `https://acmurl.com/${shortlink}`];
+}

--- a/src/assets/notionCalSchema.ts
+++ b/src/assets/notionCalSchema.ts
@@ -3,7 +3,7 @@
  * 
  * This effectively is a copy of the `database.properties` JSON object
  * extracted from a copy of the ACM UCSD Notion Calendar as of
- * Wed, Dec 14 2022 19:54:13 PST.
+ * Fri, Jan 27 2023 19:54:13 PST.
  */
 export const notionCalSchema = {
   'Funding Status': {
@@ -488,7 +488,7 @@ export const notionCalSchema = {
         },
         {
           'id': '1b940d3d-4d1b-49bd-869c-1819febb4a28',
-          'name': 'Design and Innovation Building 202',
+          'name': 'Design and Innovation Building 202/208',
           'color': 'gray',
         },
         {
@@ -882,7 +882,7 @@ export const notionCalSchema = {
         },
         {
           'id': 'fcbc2e96-5248-4d6c-bfd2-ea254708e16c',
-          'name': 'Design and Innovation Building 202',
+          'name': 'Design and Innovation Building 202/208',
           'color': 'gray',
         },
         {
@@ -1268,7 +1268,7 @@ export const notionCalSchema = {
         },
         {
           'id': '62606abb-4b3e-4218-af53-2c7a0228707b',
-          'name': 'Design and Innovation Building 202',
+          'name': 'Design and Innovation Building 202/208',
           'color': 'gray',
         },
         {

--- a/src/commands/MeetingNotes.ts
+++ b/src/commands/MeetingNotes.ts
@@ -1,8 +1,11 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, MessageEmbed } from 'discord.js';
 import { DateTime } from 'luxon';
+import { ACMURLConfig, addACMURL, handleExistingACMURL } from '../acmurl';
 import Command from '../Command';
-import { BotClient } from '../types';
+import { BotClient, UUIDv4 } from '../types';
+import { v4 as newUUID } from 'uuid';
+import Logger from '../utils/Logger';
 
 /**
  * Makes a new meeting note on Notion and provides a link to it.
@@ -16,6 +19,8 @@ export default class MeetingNotes extends Command {
         .setRequired(true))
       .addStringOption((option) => option.setName('date')
         .setDescription('MM/DD/YYYY (Defaults to today\'s date)'))
+      .addStringOption((option) => option.setName('shortlink')
+        .setDescription('Shortens the link to acmurl.com/{shortlink}!'))
       .setDescription('Makes a new meeting note on Notion with the given title and links to it.');
 
     super(client, {
@@ -27,6 +32,68 @@ export default class MeetingNotes extends Command {
       usage: client.settings.prefix.concat('meetingnotes'),
       requiredPermissions: ['SEND_MESSAGES'],
     }, definition);
+  }
+
+  /**
+   * Shortens the given long link into acmurl.com/{shortlink}.
+   * @param interaction The command interaction from the called command, so we can edit it in the event of an error.
+   * @param shortlink The shortened ID to shorten the link to (acmurl.com/{shortlink})
+   * @param longlink The long link to shorten (here, a link to the Notion meeting notes)
+   * @returns The new shortened link, or null in the event of an error.
+   */
+  private async makeACMURL(
+    interaction: CommandInteraction, shortlink: string, longlink: string,
+  ): Promise<string | null> {
+    const linkTitle = `Discord Bot: ${shortlink}`;
+    const config: ACMURLConfig = {
+      username: this.client.settings.acmurl.username,
+      password: this.client.settings.acmurl.password,
+    };
+    try {
+      const shortURL = await addACMURL(shortlink, longlink, linkTitle, config);
+      return shortURL;
+    } catch (e) {
+      // We might error out if an ACMURL already exists with the provided shortlink.
+      // We'll attempt to handle that by updating the ACMURL.
+      const errorUUID: UUIDv4 = newUUID();
+
+      const error = e as any;
+
+      // If the error we get is specifically that a ACMURL already existed.
+      if (error.message === 'error:keyword') {
+        try {
+          // Make a new one and return the old long link and new ACMURL
+          const [, newURL] = await handleExistingACMURL(
+            shortlink, longlink, linkTitle, config,
+          );
+          return newURL;
+        } catch (e2) {
+          const updateError = e2 as any;
+          // If by any chance there's an error when updating the ACMURL, log it and return.
+          Logger.error(`Error whilst updating short URL on YOURLS API: ${updateError.message}`, {
+            eventType: 'interfaceError',
+            interface: 'YOURLS',
+            error: updateError,
+            uuid: errorUUID,
+          });
+          await super.edit(interaction, 
+            `An error occurred when attempting to update the short URL. *(Error UUID: ${errorUUID})*`,
+          );
+          return null;
+        }
+      } else {
+        // If the error we had initially when adding the ACMURL is any other error,
+        // log it and return.
+        Logger.error(`Error whilst creating short URL on YOURLS API: ${error.message}`, {
+          eventType: 'interfaceError',
+          interface: 'YOURLS',
+          error,
+          uuid: errorUUID,
+        });
+        await super.edit(interaction, `An error occurred when shortening the URL. *(Error UUID: ${errorUUID})*`);
+        return null;
+      }
+    }
   }
 
   public async run(interaction: CommandInteraction): Promise<void> {
@@ -49,13 +116,23 @@ export default class MeetingNotes extends Command {
     
     // We automatically add the date of the note to the start of the title.
     const title = date.toFormat('MM/dd/yyyy') + ' ' + interaction.options.getString('title', true);
-    const url = await this.client.notionEventSyncManager.generateMeetingNotes(this.client, title, date);
+    let url = await this.client.notionEventSyncManager.generateMeetingNotes(this.client, title, date);
+    const shortlink = interaction.options.getString('shortlink', false);
     if (url) {
       // If the url isn't empty, the note was successfully made!
-      const messageEmbed = new MessageEmbed()
+      let embedDescription = `**Title:** ${title}\n**Link:** ${url}`;
+      
+      if (shortlink) {
+        // A shortlink was provided, so we'll shorten the url here.
+        const shortURL = await this.makeACMURL(interaction, shortlink, url);
+        if (shortURL) {
+          embedDescription += `\n**Shortened Link:** ${shortURL}`;
+        }
+      }
+      let messageEmbed = new MessageEmbed()
         .setTitle('📝 Created a new meeting note!')
         .setURL(url)
-        .setDescription(`**Title:** ${title}\n**Link:** ${url}`)
+        .setDescription(embedDescription)
         .setColor('BLUE');
       super.edit(interaction, { embeds: [messageEmbed], ephemeral: false });
     } else {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -41,4 +41,8 @@ export default {
   logisticsTeamID: '',
   botErrorChannelID: '',
   scheduledMessageGoogleCalendarID: '',
+  acmurl: {
+    username: '',
+    password: '',
+  },
 } as BotSettings;

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -151,6 +151,14 @@ export interface BotSettings {
    * Scheduled Message Calendar ID, used for backing up scheduled messages.
    */
   scheduledMessageGoogleCalendarID: string;
+
+  /** 
+   * ACMURL credentials. Used in the /meetingnotes command 
+   */
+  acmurl: {
+    username: string,
+    password: string,
+  }
 }
   
 /**

--- a/src/types/notion.ts
+++ b/src/types/notion.ts
@@ -34,7 +34,7 @@ export type EventLocation = 'Zoom (See Details)'
 | 'CSE B225 (Fishbowl)'
 | 'PC Forum'
 | 'PC Bear Room'
-| 'Design and Innovation Building 202';
+| 'Design and Innovation Building 202/208';
 
 /**
  * Converter from the Host Form's locations to the Notion Calendar
@@ -59,7 +59,7 @@ export const notionLocationTag = {
   'CSE 1202': 'CSE 1202',
   'CSE B225': 'CSE B225 (Fishbowl)',
   'CSE Labs': 'Other (See Details)',
-  'Design and Innovation Building Room 202': 'Design and Innovation Building 202',
+  'Design and Innovation Building Room 202': 'Design and Innovation Building 202/208',
   'Fung Auditorium (Paid)': 'Fung Auditorium',
   'Warren Bear': 'Warren Bear',
   'Warren College SAC': 'Warren College SAC',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,6 +2813,11 @@ uuid@^8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"


### PR DESCRIPTION
- Add ACMURL code in ./src/acmurl
- Add ACMURL shortlink option to /meetingnotes command
  - added `uuid` library to catch errors here (used in BreadBot as well)
<img width="609" alt="Screen Shot 2023-01-27 at 5 25 32 PM" src="https://user-images.githubusercontent.com/27360825/215234227-59647084-47cc-4f4e-9bab-0dc1a82ee842.png">
- Update Notion Calendar schema to change "Design and Innovation Building 202" to "Design and Innovation Building 202/208" per Events team request
<img width="665" alt="Screen Shot 2023-01-27 at 5 26 14 PM" src="https://user-images.githubusercontent.com/27360825/215234257-4205aa8c-160e-485a-b3de-34b0aa16c283.png">
