### PR TITLE
Modify previous key ping reminders to be relevant for CSE/Qualcomm key codes & DIB key card

### DIFF
--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -694,9 +694,9 @@ export const pingForTAPandCSIDeadlines = async (
 /**
  * Pings the Logistics Team to remind them to get keys for particular rooms that require them.
  *
- * Every event in any CSE building room that is not CSE B225 ("The Fishbowl") requires keys.
+ * All rooms in DIB, CSE (apart from CSE B225/"The Fishbowl"), or the Qualcomm Room require key codes/cards
  */
-const keyPingDays = 4;
+const keyPingDays = 4; // Decided 4 to give event coordinators extra notice in advance of weekends
 const keyTextLocs = "Qualcomm, DIB, and CSE rooms";
 const keyCardLocs = ['Design and Innovation Building 202/208'];
 const keyCodeLocs = ['CSE 1202', 'CSE 2154', 'CSE 4140', 'Qualcomm Room'];

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -716,8 +716,7 @@ export const pingForKeys = async (notion: Client, databaseId: string, config: Ev
           },
         },
         {
-          or: allLocs
-          .map((location) => {
+          or: allLocs.map((location) => {
             return {
               property: 'Location',
               select: {
@@ -731,6 +730,7 @@ export const pingForKeys = async (notion: Client, databaseId: string, config: Ev
   });
 
   const allEvents = eventsResponse.results as PageObjectResponse[];
+
   Logger.debug(`Querying Notion API for events on date ${keyPingDate.toISODate()} in ${keyTextLocs}...`);
   const activeEvents = allEvents.filter((event) => {
     if (event.properties.Type.type !== 'select') {

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -777,7 +777,7 @@ hosting [${event.properties.Name.title.reduce((acc, curr) => acc + curr.plain_te
   // Now that we have all of them grouped up, we can build the embed.
   const keyPingEmbed = new MessageEmbed()
     .setTitle(`Don't forget to arrange key cards/codes for the following events on \
-    ${keyPingDate.toLocaleString(DateTime.DATE_FULL)}`)
+${keyPingDate.toLocaleString(DateTime.DATE_FULL)}`)
     .setColor('GREEN')
     .setDescription(keyPingDescription)
 


### PR DESCRIPTION
Many rooms we use no longer require physical keys, and instead key codes (CSE or Qualcomm in Jacobs) or a key card (DIB). 

This changes reminders to reflect that, with pings being <keyPingDays> in advance (set at 4 days for now after discussion with Event Coordinators).

<img width="437" alt="image" src="https://github.com/acmucsd/kartana/assets/45515570/cab77cbe-3162-46b5-acaa-783ba75f93c4">
