### PR TITLE
Automate PEEF reminders and completion pings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ BOT_ACTIVITY=
 # Note that NO guarantees for the script are made unless
 # the below environment variables are properly set.
 
+# Runtime data directory 
+# Defaults to ./data when omitted.
+BOT_DATA_DIR=
+
 # The credentials required for the Notion Integration
 # connected to the ACM UCSD Board Notion.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -263,6 +263,9 @@ database.properties
 meetingPingsCalendarSchema.*
 meetingPingsGuestSchema.*
 
+# Peef Pings State
+peefReminderState.*
+
 /secrets
 
 # Debug output files

--- a/.gitignore
+++ b/.gitignore
@@ -259,12 +259,8 @@ gapi-service-account-creds.json
 database.properties
 
 .DS_Store
-# Meeting Pings Schema
-meetingPingsCalendarSchema.*
-meetingPingsGuestSchema.*
-
-# Peef Pings State
-peefReminderState.*
+# Runtime data files
+data/
 
 /secrets
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ as `.env`. Check the comments in the file for details. If you need any help
 acquiring the credentials in the `.env.example` file, consult the `SECURITY.md`
 file for details, along with the other docs for any specific pipeline to configure.
 
+Runtime state files are stored in a data directory configured by `BOT_DATA_DIR`.
+If omitted, Kartana defaults to `./data`.
+
+For Docker deployments, set `BOT_DATA_DIR=/data` and mount `/data` as a volume.
+
 Kartana can be run using:
 
 ```sh

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,5 +1,6 @@
 import { Collection, Client as DiscordClient } from 'discord.js';
 import { Service } from 'typedi';
+import { mkdirSync } from 'fs';
 import Logger from './utils/Logger';
 import { BotSettings, BotClient, BotInitializationError } from './types';
 import Command from './Command';
@@ -141,6 +142,7 @@ export default class Client extends DiscordClient implements BotClient {
     this.settings.token = process.env.BOT_TOKEN;
     this.settings.prefix = process.env.BOT_PREFIX;
     this.settings.notionIntegrationToken = process.env.NOTION_INTEGRATION_TOKEN;
+    this.settings.dataDir = process.env.BOT_DATA_DIR || this.settings.dataDir;
     this.settings.notionCalendarID = process.env.NOTION_CALENDAR_ID;
     this.settings.notionMeetingNotesID = process.env.NOTION_MEETING_NOTES_ID;
     this.settings.notionHostedEventsID = process.env.NOTION_HOSTED_EVENTS_ID;
@@ -158,6 +160,9 @@ export default class Client extends DiscordClient implements BotClient {
     this.settings.scheduledMessageGoogleCalendarID = process.env.SCHEDULED_MESSAGE_GOOGLE_CALENDAR_ID;
     this.settings.acmurl.username = process.env.ACMURL_USERNAME;
     this.settings.acmurl.password = process.env.ACMURL_PASSWORD;
+
+    mkdirSync(this.settings.dataDir, { recursive: true });
+
     this.initialize().then();
   }
 

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -1,3 +1,4 @@
 export * from './notionCalSchema';
 export * from './googleSheetSchema';
 export * from './notionHostedEventDescription';
+export * from './notionHostedEvent';

--- a/src/assets/notionCalSchema.ts
+++ b/src/assets/notionCalSchema.ts
@@ -682,21 +682,6 @@ export const notionCalSchema = {
       ],
     },
   },
-  'Hosted Events Sheet': {
-    id: 'ICQM',
-    name: 'Hosted Events Sheet',
-    description: null,
-    type: 'relation',
-    relation: {
-      database_id: '2b914391-5b12-81e6-bfa3-c4c639ad77a3',
-      data_source_id: '2b914391-5b12-8131-9c5b-000b1eacc404',
-      type: 'dual_property',
-      dual_property: {
-        synced_property_name: 'Calendar Event',
-        synced_property_id: 'QZWa',
-      },
-    },
-  },
   'Recording Requests': {
     id: 'LYO%3D',
     name: 'Recording Requests',
@@ -719,6 +704,21 @@ export const notionCalSchema = {
     description: null,
     type: 'files',
     files: {},
+  },
+  'Hosted Events Sheet': {
+    id: 'SXzi',
+    name: 'Hosted Events Sheet',
+    description: null,
+    type: 'relation',
+    relation: {
+      database_id: 'd26e4598-91dc-4222-895e-559b15d7cd19',
+      data_source_id: '8123c750-41b1-4ac5-b4bf-90f2d2471a8f',
+      type: 'dual_property',
+      dual_property: {
+        synced_property_name: 'Calendar Event',
+        synced_property_id: 'scC%7B',
+      },
+    },
   },
   'Event Coordinator': {
     id: 'TC0%24',
@@ -984,7 +984,7 @@ export const notionCalSchema = {
           description: null,
         },
         {
-          id: '0e47aa5a-b6b2-47a2-a071-3faf811e940f',
+          id: 'Aw:a',
           name: 'Other',
           color: 'brown',
           description: null,
@@ -1765,4 +1765,4 @@ export const notionCalSchema = {
     type: 'title',
     title: {},
   },
-};
+} as const;

--- a/src/assets/notionCalSchema.ts
+++ b/src/assets/notionCalSchema.ts
@@ -682,6 +682,21 @@ export const notionCalSchema = {
       ],
     },
   },
+  'Hosted Events Sheet': {
+    id: 'ICQM',
+    name: 'Hosted Events Sheet',
+    description: null,
+    type: 'relation',
+    relation: {
+      database_id: '2b914391-5b12-81e6-bfa3-c4c639ad77a3',
+      data_source_id: '2b914391-5b12-8131-9c5b-000b1eacc404',
+      type: 'dual_property',
+      dual_property: {
+        synced_property_name: 'Calendar Event',
+        synced_property_id: 'QZWa',
+      },
+    },
+  },
   'Recording Requests': {
     id: 'LYO%3D',
     name: 'Recording Requests',
@@ -704,21 +719,6 @@ export const notionCalSchema = {
     description: null,
     type: 'files',
     files: {},
-  },
-  'Hosted Events Sheet': {
-    id: 'SXzi',
-    name: 'Hosted Events Sheet',
-    description: null,
-    type: 'relation',
-    relation: {
-      database_id: 'd26e4598-91dc-4222-895e-559b15d7cd19',
-      data_source_id: '8123c750-41b1-4ac5-b4bf-90f2d2471a8f',
-      type: 'dual_property',
-      dual_property: {
-        synced_property_name: 'Calendar Event',
-        synced_property_id: 'scC%7B',
-      },
-    },
   },
   'Event Coordinator': {
     id: 'TC0%24',
@@ -984,7 +984,7 @@ export const notionCalSchema = {
           description: null,
         },
         {
-          id: 'Aw:a',
+          id: '0e47aa5a-b6b2-47a2-a071-3faf811e940f',
           name: 'Other',
           color: 'brown',
           description: null,
@@ -1765,4 +1765,4 @@ export const notionCalSchema = {
     type: 'title',
     title: {},
   },
-} as const;
+};

--- a/src/assets/notionHostedEvent.ts
+++ b/src/assets/notionHostedEvent.ts
@@ -1,0 +1,184 @@
+/**
+ * The Notion Hosted Event database schema.
+ *
+ * Extracted from Notion API using the `get-database-props.js` script.
+ */
+export const notionHostedEvent = {
+  'Funding?': {
+    id: '%3E%3Bv%5D',
+    name: 'Funding?',
+    description: null,
+    type: 'select',
+    select: {
+      options: [
+        {
+          id: 'Lz^I',
+          name: 'Yes',
+          color: 'green',
+          description: null,
+        },
+        {
+          id: 'oQn[',
+          name: 'No',
+          color: 'red',
+          description: null,
+        },
+      ],
+    },
+  },
+  Team: {
+    id: '%3Fsuf',
+    name: 'Team',
+    description: null,
+    type: 'select',
+    select: {
+      options: [
+        {
+          id: '7796b177-1111-4e44-ad74-93dd553ed47e',
+          name: 'Board',
+          color: 'yellow',
+          description: null,
+        },
+        {
+          id: 'ec733d97-9ebd-4bf9-bf2c-ce69675e7520',
+          name: 'Development',
+          color: 'default',
+          description: null,
+        },
+        {
+          id: '75a70a6a-ca4c-413e-91b0-1af58db97abf',
+          name: 'Events',
+          color: 'blue',
+          description: null,
+        },
+        {
+          id: 'b7b5dc83-6f85-43f4-b603-5330754e015c',
+          name: 'Finance',
+          color: 'brown',
+          description: null,
+        },
+        {
+          id: 'aaaddb16-d2f6-4605-8051-b264b6962a8c',
+          name: 'Membership',
+          color: 'purple',
+          description: null,
+        },
+        {
+          id: '9a14180b-4abd-42a0-aee9-ef17ccd089a1',
+          name: 'Projects',
+          color: 'brown',
+          description: null,
+        },
+        {
+          id: '2d7414d8-92cf-4ffd-ac37-5f606f298bdb',
+          name: 'AI',
+          color: 'red',
+          description: null,
+        },
+        {
+          id: '7bd5a7bb-65fd-4382-807e-fa09c27ac698',
+          name: 'Cyber',
+          color: 'green',
+          description: null,
+        },
+        {
+          id: 'fbce377a-38ca-4982-870f-0c85135689d6',
+          name: 'Design',
+          color: 'pink',
+          description: null,
+        },
+        {
+          id: '278dab57-19bb-47e1-828c-0f7f78ddd12e',
+          name: 'Hack',
+          color: 'orange',
+          description: null,
+        },
+        {
+          id: '69d3b605-4f35-49e9-a665-ee97171687a2',
+          name: 'Hackathon',
+          color: 'gray',
+          description: null,
+        },
+      ],
+    },
+  },
+  'Calendar Event': {
+    id: 'QZWa',
+    name: 'Calendar Event',
+    description: null,
+    type: 'relation',
+    relation: {
+      database_id: '2b114391-5b12-8196-b759-e5bf91f51489',
+      data_source_id: '2b114391-5b12-8117-9eee-000b3b31dbf6',
+      type: 'dual_property',
+      dual_property: {
+        synced_property_name: 'Hosted Events Sheet',
+        synced_property_id: 'ICQM',
+      },
+    },
+  },
+  'Host(s)': {
+    id: 'QqJq',
+    name: 'Host(s)',
+    description: null,
+    type: 'people',
+    people: {},
+  },
+  'Event Type': {
+    id: '%5B%5CEs',
+    name: 'Event Type',
+    description: null,
+    type: 'rich_text',
+    rich_text: {},
+  },
+  'Marketing?': {
+    id: '%5CBw%3A',
+    name: 'Marketing?',
+    description: null,
+    type: 'select',
+    select: {
+      options: [
+        {
+          id: 'W_:?',
+          name: 'Yes',
+          color: 'green',
+          description: null,
+        },
+        {
+          id: 'a=IJ',
+          name: 'No',
+          color: 'red',
+          description: null,
+        },
+      ],
+    },
+  },
+  Date: {
+    id: '%5CcKz',
+    name: 'Date',
+    description: null,
+    type: 'date',
+    date: {},
+  },
+  'PEEF Submitted': {
+    id: 'i%40Yr',
+    name: 'PEEF Submitted',
+    description: null,
+    type: 'checkbox',
+    checkbox: {},
+  },
+  'PEEF Written': {
+    id: 'yE%3Ek',
+    name: 'PEEF Written',
+    description: null,
+    type: 'checkbox',
+    checkbox: {},
+  },
+  Name: {
+    id: 'title',
+    name: 'Name',
+    description: null,
+    type: 'title',
+    title: {},
+  },
+} as const;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -30,6 +30,7 @@ export default {
     events: 'src/events',
   },
   notionIntegrationToken: '',
+  dataDir: 'data',
   notionCalendarID: '',
   notionMeetingNotesID: '',
   notionHostedEventsID: '',

--- a/src/event-notion/NotionCalEvent.ts
+++ b/src/event-notion/NotionCalEvent.ts
@@ -97,6 +97,14 @@ function parseLocationURL(urlString: string, eventName: string): URL | null {
   }
 }
 
+const asEnumValues = <T extends string>(values: readonly T[]): [T, ...T[]] => {
+  if (values.length === 0) {
+    throw new Error('Cannot build zod enum from an empty array.');
+  }
+
+  return [...values] as [T, ...T[]];
+};
+
 /**
  * Zod schema validating input (HostFormResponse) and mapping to output (INotionCalEvent)
  */
@@ -108,12 +116,12 @@ export const HostFormResponseSchema = z
     'Event Title': z.string().min(1, 'Event title is required'),
     'Event description': z.string().min(1, 'Event description is required'),
     'Plain description': z.string().min(1, 'Plain description is required'),
-    'Are you planning on inviting off campus guests?': z.enum(offCampusGuests, {
+    'Are you planning on inviting off campus guests?': z.enum(asEnumValues(offCampusGuests), {
       errorMap: (event) => ({
         message: `Invalid off campus guest status: ${event}`,
       }),
     }),
-    'What kind of event is this?': z.enum(eventTypes).catch('Other (See Comments)'),
+    'What kind of event is this?': z.enum(asEnumValues(eventTypes)).catch('Other (See Comments)'),
     'Preferred date': z.string(),
     'Preferred start time': z.string(),
     'Preferred end time': z.string(),
@@ -125,17 +133,17 @@ export const HostFormResponseSchema = z
     'Check-in Code': z.string().min(1, 'Check-in code is required, else put N/A'),
     'Which of the following organizations are involved in this event?': z.preprocess(
       (val) => (val as string).split(',').map((org) => org.trim()),
-      z.array(z.enum(studentOrgs).catch('Other' as StudentOrg)),
+      z.array(z.enum(asEnumValues(studentOrgs)).catch('Other' as StudentOrg)),
     ),
-    'If this is a collab event, who will be handling the logistics?': z.enum(logisticsBy, {
+    'If this is a collab event, who will be handling the logistics?': z.enum(asEnumValues(logisticsBy), {
       errorMap: (event) => ({
         message: `Invalid logistics handler: ${event}`,
       }),
     }),
-    'Which pass will this event be submitted under?': z.enum(tokenPasses, {
+    'Which pass will this event be submitted under?': z.enum(asEnumValues(tokenPasses), {
       errorMap: (event) => ({ message: `Invalid pass: ${event}` }),
     }),
-    'Which team/community will be using their token?': z.enum(tokenEventGroups, {
+    'Which team/community will be using their token?': z.enum(asEnumValues(tokenEventGroups), {
       errorMap: (event) => ({
         message: `Invalid token team/community: ${event}`,
       }),
@@ -155,7 +163,7 @@ export const HostFormResponseSchema = z
       })
       .catch('Other'), //z.string().optional().default(''),
     'Other venue details?': z.string().optional().default(''),
-    'Will you need a projector and/or other tech?': z.enum(projectorStatuses).catch('No'),
+    'Will you need a projector and/or other tech?': z.enum(asEnumValues(projectorStatuses)).catch('No'),
     'If you need tech or equipment, please specify here': z.string().optional().default(''),
     // Section 4 - Conditional based on venue
     'Event Link (ACMURL)': z.string().optional().default(''),
@@ -165,7 +173,7 @@ export const HostFormResponseSchema = z
     'What food do you need funding for?': z.string().optional().default(''),
     'Food Pickup Time': z.string().optional(),
     'Non-food system requests: Vendor website or menu': z.string().optional().default(''),
-    'Is there a sponsor that will pay for this event?': z.enum(fundingSponsor).catch('No'),
+    'Is there a sponsor that will pay for this event?': z.enum(asEnumValues(fundingSponsor)).catch('No'),
     'Any additional funding details?': z.string().optional().default(''),
   })
   .superRefine((data, ctx) => {

--- a/src/event-notion/NotionPeefReminderState.ts
+++ b/src/event-notion/NotionPeefReminderState.ts
@@ -33,7 +33,7 @@ export default class NotionPeefReminderState {
    * @returns Persisted milestone data, or an empty object if this event has never been seen.
    */
   public get(eventId: string): PeefReminderMilestones {
-    return this.state[eventId] || {};
+    return { ...(this.state[eventId] || {}) };
   }
 
   /**
@@ -51,7 +51,7 @@ export default class NotionPeefReminderState {
       return;
     }
 
-    this.state[eventId] = milestones;
+    this.state[eventId] = { ...milestones };
 
     try {
       fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2));

--- a/src/event-notion/NotionPeefReminderState.ts
+++ b/src/event-notion/NotionPeefReminderState.ts
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import Logger from '../utils/Logger';
+
+const DEFAULT_PEEF_REMINDER_STATE_PATH = 'peefReminderState.json';
+
+export interface PeefReminderMilestones {
+  postEventReminderSentAt?: string;
+  preDeadlineReminderSentAt?: string;
+  completionAlertSentAt?: string;
+  wasPeefWritten?: boolean;
+}
+
+type PeefReminderState = Record<string, PeefReminderMilestones>;
+
+/**
+ * Handles persistence and retrieval of PEEF reminder milestones.
+ *
+ * This class stores per-event reminder state on disk so cron-based checks are idempotent
+ * across process restarts. Each event is keyed by its Notion page ID and tracks whether
+ * post-event reminders, pre-deadline reminders, and completion alerts were already sent.
+ */
+export default class NotionPeefReminderState {
+  private state: PeefReminderState;
+
+  constructor(private readonly filePath = DEFAULT_PEEF_REMINDER_STATE_PATH) {
+    this.state = this.load();
+  }
+
+  /**
+   * Returns stored milestones for a Notion event.
+   *
+   * @param eventId Notion page ID for the hosted event.
+   * @returns Persisted milestone data, or an empty object if this event has never been seen.
+   */
+  public get(eventId: string): PeefReminderMilestones {
+    return this.state[eventId] || {};
+  }
+
+  /**
+   * Persists milestones for a Notion event immediately.
+   *
+   * This method performs a no-op when data is unchanged, which helps avoid unnecessary
+   * filesystem writes on every cron run.
+   *
+   * @param eventId Notion page ID for the hosted event.
+   * @param milestones Updated milestone values to persist.
+   */
+  public set(eventId: string, milestones: PeefReminderMilestones): void {
+    const existingMilestones = this.state[eventId];
+    if (JSON.stringify(existingMilestones || {}) === JSON.stringify(milestones || {})) {
+      return;
+    }
+
+    this.state[eventId] = milestones;
+
+    try {
+      fs.writeFileSync(this.filePath, JSON.stringify(this.state, null, 2));
+    } catch (err) {
+      Logger.error(`Error saving PEEF reminder state: ${err}`);
+    }
+  }
+
+  /**
+   * Loads the persisted reminder state file from disk.
+   *
+   * If the file does not exist yet, an empty JSON object is initialized to establish
+   * a valid baseline for subsequent reads and writes.
+   */
+  private load(): PeefReminderState {
+    try {
+      if (!fs.existsSync(this.filePath)) {
+        fs.writeFileSync(this.filePath, '{}');
+        return {};
+      }
+
+      const contents = fs.readFileSync(this.filePath, { encoding: 'utf-8' }).trim();
+      if (contents === '') {
+        return {};
+      }
+
+      return JSON.parse(contents) as PeefReminderState;
+    } catch (err) {
+      Logger.error(`Error loading PEEF reminder state, using empty state: ${err}`);
+      return {};
+    }
+  }
+}

--- a/src/event-notion/NotionPeefReminderState.ts
+++ b/src/event-notion/NotionPeefReminderState.ts
@@ -1,7 +1,8 @@
 import fs from 'fs';
+import path from 'path';
 import Logger from '../utils/Logger';
 
-const DEFAULT_PEEF_REMINDER_STATE_PATH = 'peefReminderState.json';
+const DEFAULT_PEEF_REMINDER_STATE_FILE_NAME = 'peefReminderState.json';
 
 export interface PeefReminderMilestones {
   postEventReminderSentAt?: string;
@@ -22,7 +23,10 @@ type PeefReminderState = Record<string, PeefReminderMilestones>;
 export default class NotionPeefReminderState {
   private state: PeefReminderState;
 
-  constructor(private readonly filePath = DEFAULT_PEEF_REMINDER_STATE_PATH) {
+  private readonly filePath: string;
+
+  constructor(dataDir: string) {
+    this.filePath = path.join(dataDir, DEFAULT_PEEF_REMINDER_STATE_FILE_NAME);
     this.state = this.load();
   }
 

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -1,6 +1,6 @@
 import { Client } from '@notionhq/client';
 import Logger from '../utils/Logger';
-import { notionCalSchema, googleSheetSchema } from '../assets';
+import { notionCalSchema, googleSheetSchema, notionHostedEvent } from '../assets';
 import { GetDatabaseResponse, PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { diff } from 'json-diff-ts';
 import { groupBy, isEqual } from 'lodash';
@@ -10,6 +10,7 @@ import { GoogleSpreadsheet, GoogleSpreadsheetRow, ServiceAccountCredentials } fr
 import { ColorResolvable, MessageEmbed, TextChannel } from 'discord.js';
 import { DateTime } from 'luxon';
 import { MeetingPingsSchema } from '../meeting-pings';
+import NotionPeefReminderState, { PeefReminderMilestones } from './NotionPeefReminderState';
 
 /**
  * Logs into Notion.
@@ -38,6 +39,21 @@ export const validateNotionDatabase = (database: GetDatabaseResponse) => {
   const databaseDiff = diff(notionCalSchemaFiltered, databasePropsFiltered);
   if (databaseDiff.length !== 0) {
     Logger.error('Notion Calendar schema is mismatched! Halting!', {
+      type: 'error',
+      diff: databaseDiff,
+    });
+    throw new NotionSchemaMismatchError(databaseDiff);
+  }
+};
+
+/**
+ * Validates the Hosted Events Notion database schema used for PEEF reminders.
+ * @param database Hosted Events Notion database response.
+ */
+export const validateNotionHostedEventDatabase = (database: GetDatabaseResponse) => {
+  const databaseDiff = diff(notionHostedEvent, database.properties);
+  if (databaseDiff.length !== 0) {
+    Logger.error('Notion Hosted Events schema is mismatched! Halting!', {
       type: 'error',
       diff: databaseDiff,
     });
@@ -737,6 +753,215 @@ hosting [${event.properties.Name.title.reduce((acc, curr) => acc + curr.plain_te
 };
 
 /**
+ * Pings event hosts for pending PEEFs and pings Finance Team when a PEEF is completed.
+ *
+ * This includes:
+ * - Ping hosts once event has concluded by at least 1 hour and PEEF is not written.
+ * - Ping hosts once again the Saturday morning before the PEEF is due (Sunday) if PEEF is still not written.
+ * - Ping Finance Team immediately once PEEF is marked complete.
+ */
+export const pingForPEEFReminders = async (config: EventNotionPipelineConfig) => {
+  Logger.info('Setting up PEEF reminder checks...');
+  const notion = await getNotionAPI(config.settings.notionIntegrationToken);
+
+  const databaseId = config.settings.notionHostedEventsID;
+  const database = await notion.databases.retrieve({ database_id: databaseId });
+  validateNotionHostedEventDatabase(database);
+
+  const getPageTitle = (event: PageObjectResponse): string => {
+    if (event.properties.Name.type !== 'title') {
+      return '(Untitled Event)';
+    }
+
+    const title = event.properties.Name.title.reduce((acc, curr) => acc + curr.plain_text, '').trim();
+    return title || '(Untitled Event)';
+  };
+
+  const queryAllEvents = async (): Promise<PageObjectResponse[]> => {
+    const events: PageObjectResponse[] = [];
+    let cursor: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const response = await notion.databases.query({
+        database_id: databaseId,
+        start_cursor: cursor,
+      });
+
+      response.results.forEach((result) => {
+        if ('properties' in result) {
+          events.push(result as PageObjectResponse);
+        }
+      });
+
+      hasMore = response.has_more;
+      cursor = response.next_cursor ?? undefined;
+    }
+
+    return events;
+  };
+
+  const getHostMentionsAndNames = (event: PageObjectResponse, meetingPingsSchema: MeetingPingsSchema) => {
+    if (!('Host(s)' in event.properties) || event.properties['Host(s)'].type !== 'people') {
+      return { mentions: [], names: [] };
+    }
+
+    const mentions = new Set<string>();
+    const names: string[] = [];
+
+    const hostedBy = event.properties['Host(s)'] as {
+      people: Array<{ person: { email: string }; name: string }>;
+    };
+
+    hostedBy.people.forEach((person) => {
+      if (person.name) {
+        names.push(person.name);
+      }
+
+      if (person.person.email) {
+        const discordID = meetingPingsSchema.getGuest(person.person.email);
+        if (discordID) {
+          mentions.add(`<@${discordID}>`);
+        }
+      }
+    });
+
+    Logger.debug(`Mentions for event "${getPageTitle(event)}": ${Array.from(mentions).join(', ')}`);
+    Logger.debug(`Names for event "${getPageTitle(event)}": ${names.join(', ')}`);
+
+    return { mentions: Array.from(mentions), names };
+  };
+
+  const sendPeefReminder = async (
+    event: PageObjectResponse,
+    meetingPingsSchema: MeetingPingsSchema,
+    title: string,
+    message: string,
+  ) => {
+    const hosts = getHostMentionsAndNames(event, meetingPingsSchema);
+    const eventName = getPageTitle(event);
+    const hostLine = hosts.names.length > 0 ? hosts.names.join(', ') : 'No hosts assigned';
+
+    const embed = new MessageEmbed()
+      .setTitle(title)
+      .setDescription(`${message}\n\n- **Event:** [${eventName}](${event.url})\n- **Hosts:** ${hostLine}`)
+      .setColor('ORANGE');
+
+    await config.channel.send({
+      content: hosts.mentions.length > 0 ? hosts.mentions.join(' ') : undefined,
+      embeds: [embed],
+    });
+  };
+
+  const sendPeefCompletionAlert = async (event: PageObjectResponse) => {
+    const eventName = getPageTitle(event);
+    const embed = new MessageEmbed()
+      .setTitle('PEEF Completed')
+      .setDescription(`Finance Team, the PEEF is marked complete for [${eventName}](${event.url}).`)
+      .setColor('GREEN');
+
+    await config.channel.send({
+      content: `<@&${config.settings.fundingTeamID}>`,
+      embeds: [embed],
+    });
+  };
+
+  const allEvents = await queryAllEvents();
+  if (allEvents.length === 0) {
+    Logger.info('No events found while checking PEEF reminders.');
+    return;
+  }
+
+  const now = DateTime.now().setZone('America/Los_Angeles');
+  const nowISO = now.toISO() || now.toString();
+  const peefReminderState = new NotionPeefReminderState();
+  const meetingPingsSchema = new MeetingPingsSchema();
+
+  await Promise.all(
+    allEvents.map(async (event) => {
+      // skip pages that do not have a usable event date.
+      if (event.properties.Date.type !== 'date') {
+        return;
+      }
+
+      const eventDate = event.properties.Date.date;
+      if (!eventDate?.start) {
+        return;
+      }
+
+      const eventDateTime = DateTime.fromISO(eventDate.start, { zone: 'America/Los_Angeles' });
+      if (!eventDateTime.isValid) {
+        return;
+      }
+
+      if (!('PEEF Written' in event.properties) || event.properties['PEEF Written'].type !== 'checkbox') {
+        return;
+      }
+
+      const peefWritten = event.properties['PEEF Written'].checkbox;
+      const dueSunday = eventDateTime.endOf('week').endOf('day');
+      const saturdayReminderAt = dueSunday.minus({ days: 1 }).startOf('day').plus({ hours: 9 });
+      const postEventReminderAt = eventDateTime.plus({ hours: 1 });
+
+      const eventState: PeefReminderMilestones = peefReminderState.get(event.id);
+
+      // initialize state so existing completed events don't trigger a completion alert on the first run
+      if (eventState.wasPeefWritten === undefined) {
+        eventState.wasPeefWritten = peefWritten;
+        peefReminderState.set(event.id, eventState);
+      }
+
+      // only alert finance when peef goes from not written to written and no previous alert has been sent for this event
+      if (peefWritten) {
+        if (eventState.wasPeefWritten === false && !eventState.completionAlertSentAt) {
+          await sendPeefCompletionAlert(event);
+          eventState.completionAlertSentAt = nowISO;
+        }
+        eventState.wasPeefWritten = true;
+        peefReminderState.set(event.id, eventState);
+        return;
+      }
+
+      eventState.wasPeefWritten = false;
+      // persist state for overdue events in case they get marked as completed later
+      if (now >= dueSunday) {
+        peefReminderState.set(event.id, eventState);
+        return;
+      }
+
+      // send initial reminder after the event has concluded, but before the saturday reminder window
+      if (!eventState.postEventReminderSentAt && now >= postEventReminderAt && now < saturdayReminderAt) {
+        Logger.info(`Sending post-event PEEF reminder for event "${getPageTitle(event)}"`);
+
+        await sendPeefReminder(
+          event,
+          meetingPingsSchema,
+          '📝 PEEF Reminder',
+          'Your event has concluded. Please fill out the PEEF as soon as possible.',
+        );
+        eventState.postEventReminderSentAt = nowISO;
+      } else if (!eventState.preDeadlineReminderSentAt && now >= saturdayReminderAt) {
+        // send pre-deadline reminder on Saturday morning before the PEEF is due on Sunday
+        Logger.info(`Sending pre-deadline PEEF reminder for event "${getPageTitle(event)}"`);
+
+        await sendPeefReminder(
+          event,
+          meetingPingsSchema,
+          '⏰ PEEF Reminder (Due Sunday)',
+          `PEEF is due by ${dueSunday.toLocaleString(DateTime.DATETIME_FULL)}. Please submit it soon.`,
+        );
+        eventState.preDeadlineReminderSentAt = nowISO;
+      }
+
+      // update peef reminder state for this event
+      peefReminderState.set(event.id, eventState);
+    }),
+  );
+
+  Logger.info('Finished checking PEEF reminders.');
+};
+
+/**
  * Pings for any deadlines and reminders that the Teams might need for any sort of event-related task.
  *
  * This includes:
@@ -756,7 +981,6 @@ export const pingForDeadlinesAndReminders = async (config: EventNotionPipelineCo
 
   const databaseId = config.settings.notionCalendarID;
   const database = await notion.databases.retrieve({ database_id: databaseId });
-
   // Validate the Notion Calendar.
   Logger.debug('Validating schemas for data sources...');
   Logger.debug('Validating Notion database schema...');

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -826,9 +826,6 @@ export const pingForPEEFReminders = async (config: EventNotionPipelineConfig) =>
       }
     });
 
-    Logger.debug(`Mentions for event "${getPageTitle(event)}": ${Array.from(mentions).join(', ')}`);
-    Logger.debug(`Names for event "${getPageTitle(event)}": ${names.join(', ')}`);
-
     return { mentions: Array.from(mentions), names };
   };
 

--- a/src/event-notion/index.ts
+++ b/src/event-notion/index.ts
@@ -581,7 +581,7 @@ export const pingForTAPDeadlines = async (notion: Client, databaseId: string, co
 
     Object.values(cur.dates).forEach((curPing) => {
       let propDate = dateTimeNow.plus({ days: curPing.days });
-      let mps = new MeetingPingsSchema();
+      let mps = new MeetingPingsSchema(config.settings.dataDir);
 
       // Gets specific list of events that meet this ping's criteria of (date, correct org [TAP, PR, etc] status)
       let curDatePings = allEvents.filter((event) => {
@@ -716,7 +716,7 @@ export const pingForKeys = async (notion: Client, databaseId: string, config: Ev
   let curEmbedPeoplePing = new Array<string>();
 
   Object.entries(eventsByLocation).forEach(([location, events]) => {
-    let mps = new MeetingPingsSchema();
+    let mps = new MeetingPingsSchema(config.settings.dataDir);
     let needed = keyCardLocs.includes(location) ? 'card' : 'code';
     keyPingDescription += `_${location} needs a key ${needed} for these events:_\n`;
     events.forEach((event) => {
@@ -871,8 +871,8 @@ export const pingForPEEFReminders = async (config: EventNotionPipelineConfig) =>
 
   const now = DateTime.now().setZone('America/Los_Angeles');
   const nowISO = now.toISO() || now.toString();
-  const peefReminderState = new NotionPeefReminderState();
-  const meetingPingsSchema = new MeetingPingsSchema();
+  const peefReminderState = new NotionPeefReminderState(config.settings.dataDir);
+  const meetingPingsSchema = new MeetingPingsSchema(config.settings.dataDir);
 
   await Promise.all(
     allEvents.map(async (event) => {

--- a/src/managers/GoogleCalendarManager.ts
+++ b/src/managers/GoogleCalendarManager.ts
@@ -195,7 +195,7 @@ export default class {
   public async initializeMeetingPings(client: BotClient): Promise<void> {
     await this.refreshAuth(client);
     this.calendarList = [];
-    this.meetingPingsSchema = new MeetingPingsSchema();
+    this.meetingPingsSchema = new MeetingPingsSchema(client.settings.dataDir);
     for (const entry of this.meetingPingsSchema.calendarList) {
       try {
         await this.calendar.calendarList.insert({ requestBody: { id: entry.calendarID } });

--- a/src/managers/NotionEventSyncManager.ts
+++ b/src/managers/NotionEventSyncManager.ts
@@ -2,7 +2,7 @@ import { Service } from 'typedi';
 import schedule from 'node-schedule';
 import { BotClient } from '../types';
 import Logger from '../utils/Logger';
-import { syncHostFormToNotionCalendar, pingForDeadlinesAndReminders } from '../event-notion';
+import { syncHostFormToNotionCalendar, pingForDeadlinesAndReminders, pingForPEEFReminders } from '../event-notion';
 import { readFileSync } from 'fs';
 import { MessageEmbed, TextChannel } from 'discord.js';
 import { GoogleSheetsSchemaMismatchError, NotionSchemaMismatchError } from '../types';
@@ -25,7 +25,31 @@ export default class {
    */
   public deadlineReminderPingJob: schedule.Job;
 
+  /**
+   * Cronjob to run PEEF host reminders and finance completion pings.
+   */
+  public peefReminderPingJob: schedule.Job;
+
   public googleSheetKeyFile: Buffer;
+
+  private async handleNotionSchemaMismatch(client: BotClient, eventChannel: TextChannel, diff: unknown): Promise<void> {
+    if (!client.flags.validNotionSchema) {
+      return;
+    }
+
+    client.flags.validNotionSchema = false;
+
+    const errorEmbed = new MessageEmbed()
+      .setTitle('🚫 Notion database changed!')
+      .setDescription(`Changes found in database:\n\`\`\`json\n${JSON.stringify(diff, null, 2)}\n\`\`\``.slice(0, 4095))
+      .setFooter("I won't run any Notion-related pipelines again until the Notion database changes are confirmed.")
+      .setColor('DARK_RED');
+
+    await eventChannel.send({
+      content: `Paging <@&${client.settings.logisticsTeamID}> and <@&${client.settings.maintainerID}>!`,
+      embeds: [errorEmbed],
+    });
+  }
 
   /**
    * Imports new events on the Events Host Form to the private board Notion Events calendar.
@@ -48,27 +72,7 @@ export default class {
       // If we got an error, one of our schemas is mismatched! We want to call that out
       // on Discord, ping both Events Team and the Kartana developer and deal with it later on.
       if (e instanceof NotionSchemaMismatchError) {
-        // If not yet marked as invalid, don't deal with any of the logic.
-        if (client.flags.validNotionSchema) {
-          // Mark it off as invalid. We'll validate it later when we run through one pipeline run
-          // with no thrown Errors.
-          client.flags.validNotionSchema = false;
-
-          // Send the error out on Discord. If we're in this "if", it means we've
-          // not sent it before, so we'll only send once total between schema changes
-          // (or restarts).
-          const errorEmbed = new MessageEmbed()
-            .setTitle('🚫 Notion database changed!')
-            .setDescription(
-              `Changes found in database:\n\`\`\`json\n${JSON.stringify(e.diff, null, 2)}\n\`\`\``.slice(0, 4095),
-            )
-            .setFooter("I will not run the pipeline again until y'all confirm the Notion database changes.")
-            .setColor('DARK_RED');
-          await eventChannel.send({
-            content: `Paging <@&${client.settings.logisticsTeamID}> and <@&${client.settings.maintainerID}>!`,
-            embeds: [errorEmbed],
-          });
-        }
+        await this.handleNotionSchemaMismatch(client, eventChannel, e.diff);
       } else if (e instanceof GoogleSheetsSchemaMismatchError) {
         // Similarly for this if statement, except this outputs an embed for the Google Sheets table error.
         if (client.flags.validGoogleSchema) {
@@ -112,27 +116,28 @@ export default class {
       // If we got an error, our schemas are mismatched! We want to call that out
       // on Discord, ping both Events Team and the Kartana developer and deal with it later on.
       if (e instanceof NotionSchemaMismatchError) {
-        // If not yet marked as invalid, don't deal with any of the logic.
-        if (client.flags.validNotionSchema) {
-          // Mark it off as invalid. We'll validate it later when we run through one pipeline run
-          // with no thrown Errors.
-          client.flags.validNotionSchema = false;
+        await this.handleNotionSchemaMismatch(client, eventChannel, e.diff);
+      }
+    }
+  }
 
-          // Send the error out on Discord. If we're in this "if", it means we've
-          // not sent it before, so we'll only send once total between schema changes
-          // (or restarts).
-          const errorEmbed = new MessageEmbed()
-            .setTitle('🚫 Notion database changed!')
-            .setDescription(`Changes found in database:\n\`\`\`json\n${JSON.stringify(e.diff, null, 2)}\n\`\`\``)
-            .setFooter(
-              "I won't run any Notion-related pipelines again until the Notion database changes are confirmed.",
-            )
-            .setColor('DARK_RED');
-          await eventChannel.send({
-            content: `Paging <@&${process.env.DISCORD_LOGISTICS_TEAM_MENTION_ID}> and <@${process.env.DISCORD_MAINTAINER_MENTION_ID}>!`,
-            embeds: [errorEmbed],
-          });
-        }
+  /**
+   * Checks and pings for any pending PEEF reminders and completions.
+   * @param client The original client, for access to the configuration
+   */
+  public async runPEEFReminders(client: BotClient): Promise<void> {
+    const eventChannel = client.channels.cache.get(client.settings.discordEventPipelineChannelID) as TextChannel;
+    try {
+      await pingForPEEFReminders({
+        settings: client.settings,
+        channel: eventChannel,
+        googleSheetAPICredentials: JSON.parse(this.googleSheetKeyFile.toString()),
+      });
+
+      client.flags.validNotionSchema = true;
+    } catch (e) {
+      if (e instanceof NotionSchemaMismatchError) {
+        await this.handleNotionSchemaMismatch(client, eventChannel, e.diff);
       }
     }
   }
@@ -181,6 +186,10 @@ export default class {
     this.deadlineReminderPingJob = schedule.scheduleJob('0 10 * * *', async () => {
       Logger.info('Running TAP deadline pings cron job!');
       this.runDeadlinesAndReminders(client);
+    });
+    this.peefReminderPingJob = schedule.scheduleJob('*/15 * * * * *', async () => {
+      Logger.info('Running PEEF reminders cron job!');
+      this.runPEEFReminders(client);
     });
   }
 }

--- a/src/managers/NotionEventSyncManager.ts
+++ b/src/managers/NotionEventSyncManager.ts
@@ -187,7 +187,7 @@ export default class {
       Logger.info('Running TAP deadline pings cron job!');
       this.runDeadlinesAndReminders(client);
     });
-    this.peefReminderPingJob = schedule.scheduleJob('*/15 * * * * *', async () => {
+    this.peefReminderPingJob = schedule.scheduleJob('* * * * *', async () => {
       Logger.info('Running PEEF reminders cron job!');
       this.runPEEFReminders(client);
     });

--- a/src/meeting-pings/index.ts
+++ b/src/meeting-pings/index.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
 import { calendar_v3 } from 'googleapis';
 
-const GUEST_SCHEMA_FILE_PATH = 'meetingPingsGuestSchema.json';
-const CALENDAR_SCHEMA_FILE_PATH = 'meetingPingsCalendarSchema.json';
+const GUEST_SCHEMA_FILE_NAME = 'meetingPingsGuestSchema.json';
+const CALENDAR_SCHEMA_FILE_NAME = 'meetingPingsCalendarSchema.json';
 /**
  * DiscordInfo is a representation of all the information a Google Calendar needs to be paired with.
  */
@@ -26,15 +27,19 @@ interface GuestInfo {
 }
 
 export class MeetingPingsSchema {
+  private readonly guestSchemaFilePath: string;
+
+  private readonly calendarSchemaFilePath: string;
+
   // Maps a Google Calendar ID to the ID of the Discord channel to send notifications to.
   private calendarMapping: Map<string, DiscordInfo>;
 
   // Maps a calendar guest's email to their Discord user ID so we can ping them.
-  // Information is persistently stored in meetingPingsGuestSchema.json.
+  // Information is persistently stored in meetingPingsGuestSchema.json
   private guestMapping: Map<string, string>;
 
   // A list of all Google Calendars and associated information with them.
-  // Information is persistently stored in meetingPingsCalendarSchema.json.
+  // Information is persistently stored in meetingPingsCalendarSchema.json
   public calendarList: CalendarInfo[];
 
   /**
@@ -91,14 +96,13 @@ export class MeetingPingsSchema {
 
   /**
    * Initializes this.calendarList and this.calendarMapping based on the contents
-   * of meetingPingsCalendarSchema.json.
    */
   private initializeCalendarMapping(): void {
     this.calendarMapping = new Map<string, DiscordInfo>();
     this.calendarList = [];
     try {
-      if (existsSync(CALENDAR_SCHEMA_FILE_PATH)) {
-        const content = readFileSync(CALENDAR_SCHEMA_FILE_PATH, { encoding: 'utf-8' });
+      if (existsSync(this.calendarSchemaFilePath)) {
+        const content = readFileSync(this.calendarSchemaFilePath, { encoding: 'utf-8' });
         this.calendarList = JSON.parse(content) as CalendarInfo[];
         this.calendarList.forEach((calendarInfo) => {
           this.calendarMapping[calendarInfo.calendarID] = {
@@ -108,7 +112,7 @@ export class MeetingPingsSchema {
         });
       } else {
         // Create the file as a blank file if it doesn't exist.
-        writeFileSync(CALENDAR_SCHEMA_FILE_PATH, '[]');
+        writeFileSync(this.calendarSchemaFilePath, '[]');
       }
     } catch (err) {
       throw new Error(`Error while initializing calendar mapping: ${err.message}`);
@@ -116,20 +120,20 @@ export class MeetingPingsSchema {
   }
 
   /**
-   * Initializes this.guestMapping based on the contents of meetingPingsGuestSchema.json.
+   * Initializes this.guestMapping based on the contents of meetingPingsGuestSchema.json
    */
   private initializeGuestMapping(): void {
     this.guestMapping = new Map<string, string>();
     try {
-      if (existsSync(GUEST_SCHEMA_FILE_PATH)) {
-        const content = readFileSync(GUEST_SCHEMA_FILE_PATH, { encoding: 'utf-8' });
+      if (existsSync(this.guestSchemaFilePath)) {
+        const content = readFileSync(this.guestSchemaFilePath, { encoding: 'utf-8' });
         const guestInfoList = JSON.parse(content) as GuestInfo[];
         guestInfoList.forEach((guestInfo) => {
           this.guestMapping[guestInfo.email] = guestInfo.discordID;
         });
       } else {
         // Create the file as a blank file if it doesn't exist.
-        writeFileSync(GUEST_SCHEMA_FILE_PATH, '[]');
+        writeFileSync(this.guestSchemaFilePath, '[]');
       }
     } catch (err) {
       throw new Error(`Error while initializing calendar mapping: ${err.message}`);
@@ -149,7 +153,7 @@ export class MeetingPingsSchema {
 
   /**
    * Adds a new guest/updates their Discord user ID in this.guestMapping.
-   * Also saves the new information to meetingPingsGuestSchema.json.
+   * Also saves the new information to meetingPingsGuestSchema.json
    */
   public subscribeNewGuest(guestEmail: string, guestDiscordID: string): void {
     this.guestMapping[guestEmail] = guestDiscordID;
@@ -157,10 +161,12 @@ export class MeetingPingsSchema {
     Object.keys(this.guestMapping).forEach((email) => {
       writeContents.push({ email, discordID: this.guestMapping[email] });
     });
-    writeFileSync(GUEST_SCHEMA_FILE_PATH, JSON.stringify(writeContents, null, 2));
+    writeFileSync(this.guestSchemaFilePath, JSON.stringify(writeContents, null, 2));
   }
 
-  constructor() {
+  constructor(dataDir: string) {
+    this.guestSchemaFilePath = path.join(dataDir, GUEST_SCHEMA_FILE_NAME);
+    this.calendarSchemaFilePath = path.join(dataDir, CALENDAR_SCHEMA_FILE_NAME);
     this.initializeCalendarMapping();
     this.initializeGuestMapping();
   }

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -111,6 +111,11 @@ export interface BotSettings {
    */
   notionIntegrationToken: string;
 
+  /**
+   * Directory where runtime state files are stored.
+   */
+  dataDir: string;
+
   // Database IDs for pages we want to automatically create and retrieve on Notion.
   notionCalendarID: string;
   notionMeetingNotesID: string;


### PR DESCRIPTION
## Changes
- add scheduled PEEF automation job in `NotionEventSyncManager` (every minute)
- add schema for notion hosted events database (pulled using the `get-database-props` script)
- implement PEEF reminder flow in `src/event-notion/index.ts`:
  - post-event reminder 1 hour after the event concludes if not complete
  - saturday-after-9am reminder before sunday due date if still not complete
  - immediate finance ping on PEEF completion transition
- add persistent state storage in `NotionPeefReminderState` to dedupe reminder and completion pings
  - state persisted using `peefReminderState.json`
- moved runtime state files into `./data` locally by default; this directory can be configured via the environment variable `BOT_DATA_DIR`

## Notes
@edward-lemonade please confirm these data sources are correct
- PEEF source uses `NOTION_HOSTED_EVENTS_ID` env var
- Hosts' discord ID's are pulled from `meetingPingsGuestSchema.json` using their email
